### PR TITLE
add team and team admin to vars in dbt project

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ vars:
     using_contact_tags: False
     using_conversation_tags: False
     using_team: False
-    using_team_admin: False
 ```
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ vars:
     contact_history_pass_through_columns: [super_cool_contact_field]
 ```
 
-Additionally, this package includes Intercom's `company tag`, `contact tag`, `contact company`, and `conversation tag` mapping tables. If you do not use these tables, add the configuration below to your `dbt_project.yml`. By default, these variables are set to `True`:
+Additionally, this package includes Intercom's `company tag`, `contact tag`, `contact company`,`conversation tag`, `team` and `team admin` mapping tables. If you do not use these tables, add the configuration below to your `dbt_project.yml`. By default, these variables are set to `True`:
 
 ```yml
 # dbt_project.yml
@@ -57,6 +57,8 @@ vars:
     using_company_tags: False
     using_contact_tags: False
     using_conversation_tags: False
+    using_team: False
+    using_team_admin: False
 ```
 
 ## Contributions

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,7 +30,6 @@ vars:
     using_contact_tags: True
     using_conversation_tags: True
     using_team: True
-    using_team_admin: True
     
     #(Optional) Pass-through arrays.
     company_history_pass_through_columns: []

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -29,6 +29,8 @@ vars:
     using_company_tags: True
     using_contact_tags: True
     using_conversation_tags: True
+    using_team: True
+    using_team_admin: True
     
     #(Optional) Pass-through arrays.
     company_history_pass_through_columns: []

--- a/models/stg_intercom__team.sql
+++ b/models/stg_intercom__team.sql
@@ -1,3 +1,6 @@
+--To disable this model, set the using_team_ variable within your dbt_project.yml file to False.
+{{ config(enabled=var('using_team', True)) }}
+
 with base as (
 
     select * 

--- a/models/stg_intercom__team_admin.sql
+++ b/models/stg_intercom__team_admin.sql
@@ -1,5 +1,5 @@
 --To disable this model, set the using_team_admin variable within your dbt_project.yml file to False.
-{{ config(enabled=var('using_team_admin', True)) }}
+{{ config(enabled=var('using_team', True)) }}
 
 with base as (
 

--- a/models/stg_intercom__team_admin.sql
+++ b/models/stg_intercom__team_admin.sql
@@ -1,3 +1,6 @@
+--To disable this model, set the using_team_admin variable within your dbt_project.yml file to False.
+{{ config(enabled=var('using_team_admin', True)) }}
+
 with base as (
 
     select * 

--- a/models/tmp/stg_intercom__team_admin_tmp.sql
+++ b/models/tmp/stg_intercom__team_admin_tmp.sql
@@ -1,2 +1,5 @@
+--To disable this model, set the using_team_admin variable within your dbt_project.yml file to False.
+{{ config(enabled=var('using_team_admin', True)) }}
+
 select * 
 from {{ var('team_admin') }}

--- a/models/tmp/stg_intercom__team_admin_tmp.sql
+++ b/models/tmp/stg_intercom__team_admin_tmp.sql
@@ -1,5 +1,5 @@
 --To disable this model, set the using_team_admin variable within your dbt_project.yml file to False.
-{{ config(enabled=var('using_team_admin', True)) }}
+{{ config(enabled=var('using_team', True)) }}
 
 select * 
 from {{ var('team_admin') }}

--- a/models/tmp/stg_intercom__team_tmp.sql
+++ b/models/tmp/stg_intercom__team_tmp.sql
@@ -1,2 +1,5 @@
+--To disable this model, set the using_team variable within your dbt_project.yml file to False.
+{{ config(enabled=var('using_team', True)) }}
+
 select * 
 from {{ var('team') }}


### PR DESCRIPTION
I am working with a client to use Fivetran to integrate with Intercom. It appears that for their instance fivetran does not pull `team` or `team admin` from the Intercom data model, presumably this is because they do not have `team` or `team_admin` defined as it is included in the Fivetran Sync Table. I was making these changes on their local package to stop `dbt run` failing and decided to raise this as a PR instead as I saw the release of this repo is recent.

In this PR:
- add `team` and `team admin` as vars in the `dbt_project.yml` file
- update README.md to mention these new variables
- update `tmp` and `stg` models which reference `team` and `team admin` to link to the var in the project file

I plan to raise a similar change in the `Intercom` repo too. Let me know if this is helpful. Happy to close the PR and apply this to the company instance instead. 👍 