### PR TITLE
bugfix/remove-unique-test-on-company_id

### DIFF
--- a/models/stg_intercom.yml
+++ b/models/stg_intercom.yml
@@ -23,7 +23,6 @@ models:
         description: The unique identifier representing the Intercom defined company.
         tests:
           - not_null
-          - unique
       - name: company_name
         description: The name of the company.
       - name: website


### PR DESCRIPTION
Fix for this issue - https://github.com/fivetran/dbt_intercom_source/issues/30 

This PR removes a uniqueness test that was causing errors as a result of the `stg_intercom__company_history` model not being unique on `company_id` since a new row is added per company whenever the intercom company history is updated.
